### PR TITLE
fix:no permission run entrypoint

### DIFF
--- a/metastore/Dockerfile
+++ b/metastore/Dockerfile
@@ -47,6 +47,7 @@ COPY conf/metastore-site.xml ${HIVE_HOME}/conf
 COPY scripts/entrypoint.sh ${BIN_DIR}
 
 RUN chmod u+x ${HIVE_HOME}/bin/*
+RUN chmod u+x ${BIN_DIR}/entrypoint.sh
 
 EXPOSE 9083
 


### PR DESCRIPTION
in centos os, run docker-compose up -d fail, tips: runc create failed: unable to start container process: exec: "/usr/bin/entrypoint.sh": permission denied: unknown

so, grant permission in Docker file